### PR TITLE
fix: session fixation vulnerability and improve error logging

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -9,6 +9,7 @@ class RegistrationsController < ApplicationController
 
     if @user.save
       build_starter_deck(@user)
+      reset_session
       session[:user_id] = @user.id
       redirect_to dashboard_path, notice: t("registrations.flash.success")
     else
@@ -26,6 +27,7 @@ class RegistrationsController < ApplicationController
   def build_starter_deck(user)
     Cards::BuildStarterDeck.call(user)
   rescue StandardError => e
-    Rails.logger.error("BuildStarterDeck failed for user #{user.id}: #{e.message}")
+    backtrace = e.backtrace&.first(5)&.join("\n")
+    Rails.logger.error("BuildStarterDeck failed for user #{user.id}: #{e.class}: #{e.message}\n#{backtrace}")
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,8 +7,7 @@ class SessionsController < ApplicationController
     user = User.find_by(email: params[:email].to_s.downcase)
 
     if user&.authenticate(params[:password])
-      session[:user_id] = user.id
-      redirect_to dashboard_path, notice: t("sessions.flash.success")
+      login(user)
     else
       flash.now[:alert] = t("sessions.flash.invalid")
       render :new, status: :unprocessable_content
@@ -18,5 +17,13 @@ class SessionsController < ApplicationController
   def destroy
     session.delete(:user_id)
     redirect_to login_path, notice: t("sessions.flash.signed_out")
+  end
+
+  private
+
+  def login(user)
+    reset_session
+    session[:user_id] = user.id
+    redirect_to dashboard_path, notice: t("sessions.flash.success")
   end
 end


### PR DESCRIPTION
Closes #12

## Changes

- **Session fixation fix** — added `reset_session` before `session[:user_id] =` in both `SessionsController#create` and `RegistrationsController#create`; extracted private `login()` helper in `SessionsController` to keep RuboCop AbcSize in check
- **Error logging** — `rescue StandardError` in `build_starter_deck` now logs exception class and first 5 backtrace lines so failures are diagnosable in production

## Test plan

- [ ] `bundle exec rspec` — 118 examples, 0 failures
- [ ] `bundle exec rubocop` — no offenses on changed files