### PR TITLE
fix(027): remove quotes and blinking cursor from cloze card

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -96,6 +96,7 @@
     font-style: inherit;
     text-align: center;
     outline: none;
+    caret-color: transparent;
     transition: border-color 0.3s;
   }
 

--- a/app/views/review_sessions/_card_inner.html.erb
+++ b/app/views/review_sessions/_card_inner.html.erb
@@ -42,7 +42,7 @@
       <% parts = card.sentence.text.split(/#{Regexp.escape(card.form)}/i, 2) %>
       <% if parts.length == 2 && parts[0] && parts[1] %>
         <p class="font-body text-xl md:text-2xl text-on-surface-variant italic leading-relaxed max-w-2xl">
-          "<%= parts[0] %><span class="inline-input-wrapper">
+          <%= parts[0] %><span class="inline-input-wrapper">
             <input type="text"
                    autofocus
                    autocomplete="off"
@@ -50,12 +50,12 @@
                    class="inline-input"
                    data-review-target="input"
                    data-action="input->review#onInput keydown->review#trackKey" />
-          </span><%= parts[1] %>"
+          </span><%= parts[1] %>
         </p>
       <% else %>
         <%# Fallback: regular display %>
         <p class="font-body text-xl md:text-2xl text-on-surface-variant italic leading-relaxed max-w-2xl mb-4">
-          "<%= card.cloze_text %>"
+          <%= card.cloze_text %>
         </p>
         <input type="text"
                autofocus

--- a/memory-bank/features/FT-027/README.md
+++ b/memory-bank/features/FT-027/README.md
@@ -1,0 +1,23 @@
+---
+title: "FT-027: Feature Package"
+doc_kind: feature
+doc_function: index
+purpose: "Bootstrap-safe навигация по документации фичи. Читать, чтобы сначала перейти к canonical `feature.md`, а optional derived docs добавлять только после их появления."
+derived_from:
+  - ../../dna/governance.md
+  - feature.md
+status: active
+audience: humans_and_agents
+---
+
+# FT-027: Feature Package
+
+## О разделе
+
+Каталог feature package хранит canonical `feature.md`, а optional derived/external routes добавляются только после появления соответствующих документов. Сначала читай `feature.md`, затем расширяй routing по мере появления execution и decision artifacts.
+
+## Аннотированный индекс
+
+- [`feature.md`](feature.md)
+  Читать, когда нужно: открыть instantiated canonical feature-документ сразу после bootstrap нового feature package.
+  Отвечает на вопрос: где находятся scope, design, verify, blockers и canonical IDs для этой фичи.

--- a/memory-bank/features/FT-027/feature.md
+++ b/memory-bank/features/FT-027/feature.md
@@ -1,0 +1,94 @@
+---
+title: "FT-027: Cloze card: убрать кавычки и мигающий курсор"
+doc_kind: feature
+doc_function: canonical
+purpose: "Убрать литеральные кавычки вокруг cloze-предложения и скрыть мигающий текстовый caret в inline-инпуте на review-карточке."
+status: active
+delivery_status: in_progress
+audience: humans_and_agents
+must_not_define:
+  - implementation_sequence
+---
+
+# FT-027: Cloze card: убрать кавычки и мигающий курсор
+
+## What
+
+### Problem
+
+На cloze-карточке в режиме review-сессии отображаются два визуальных дефекта:
+1. Вокруг предложения показаны литеральные кавычки `"She has ___ a book"`, добавленные как текстовые символы в ERB-шаблоне.
+2. В inline-инпуте мигает текстовый курсор (caret), хотя фокус уже визуально показан через изменение цвета `border-bottom` — дублирование визуального фидбека.
+
+### Scope
+
+- `REQ-01` Убрать кавычки вокруг cloze-предложения
+- `REQ-02` Скрыть мигающий caret в inline-инпуте
+
+### Non-Scope
+
+- `NS-01` Не менять логику валидации ответа
+- `NS-02` Не менять внешний вид фокуса (border-bottom остается)
+
+### Constraints
+
+- `CON-01` Изменение только CSS и ERB-шаблона, без Ruby/JS логики
+
+## How
+
+### Solution
+
+Убрать `"` из шаблона и добавить `caret-color: transparent` в CSS. Фокус показан через border-color, caret избыточен и создает визуальный шум.
+
+### Change Surface
+
+| Surface | Why |
+| --- | --- |
+| `app/views/review_sessions/_card_inner.html.erb` | Убрать кавычки |
+| `app/assets/tailwind/application.css` | Скрыть caret |
+
+### Flow
+
+1. Пользователь видит cloze-карточку без кавычек
+2. Клик/фокус на инпут — border меняет цвет, caret не виден
+3. Ввод текста — визуально чисто, без мигающего курсора
+
+## Verify
+
+### Exit Criteria
+
+- `EC-01` Cloze-предложение отображается без кавычек
+- `EC-02` В инпуте нет мигающего курсора, фокус виден через border-color
+
+### Acceptance Scenarios
+
+- `SC-01` Пользователь открывает cloze-карточку — предложение без кавычек, при фокусе на инпут caret не виден, border подсвечен
+
+### Traceability matrix
+
+| Requirement ID | Design refs | Acceptance refs | Checks | Evidence IDs |
+| --- | --- | --- | --- | --- |
+| `REQ-01` | `CON-01` | `EC-01`, `SC-01` | `CHK-01` | `EVID-01` |
+| `REQ-02` | `CON-01` | `EC-02`, `SC-01` | `CHK-01` | `EVID-01` |
+
+### Checks
+
+| Check ID | Covers | How to check | Expected |
+| --- | --- | --- | --- |
+| `CHK-01` | `EC-01`, `EC-02`, `SC-01` | Визуальная проверка: нет кавычек, нет мигающего курсора | Предложение без кавычек, при фокусе caret не виден, border подсвечен |
+
+### Test matrix
+
+| Check ID | Evidence IDs | Evidence path |
+| --- | --- | --- |
+| `CHK-01` | `EVID-01` | `artifacts/ft-027/verify/chk-01/` |
+
+### Evidence
+
+- `EVID-01` Скриншот или результат `bin/setup --skip-server`
+
+### Evidence contract
+
+| Evidence ID | Artifact | Producer | Path contract | Reused by checks |
+| --- | --- | --- | --- | --- |
+| `EVID-01` | Скриншот или результат `bin/setup --skip-server` | verify-runner / human | `artifacts/ft-027/verify/chk-01/` | `CHK-01` |

--- a/memory-bank/features/FT-027/implementation-plan.md
+++ b/memory-bank/features/FT-027/implementation-plan.md
@@ -1,0 +1,73 @@
+---
+title: "FT-027: Implementation Plan"
+doc_kind: feature
+doc_function: derived
+purpose: "Execution-план реализации FT-027. Убрать кавычки и мигающий caret в cloze-карточке."
+derived_from:
+  - feature.md
+status: active
+audience: humans_and_agents
+must_not_define:
+  - ft_027_scope
+  - ft_027_architecture
+  - ft_027_acceptance_criteria
+  - ft_027_blocker_state
+---
+
+# План имплементации
+
+## Цель текущего плана
+
+Убрать визуальные дефекты cloze-карточки: кавычки вокруг предложения и мигающий caret в инпуте.
+
+## Current State / Reference Points
+
+| Path / module | Current role | Why relevant | Reuse / mirror |
+| --- | --- | --- | --- |
+| `app/views/review_sessions/_card_inner.html.erb:44-45,53` | ERB-шаблон cloze с литеральными `"` | Кавычки нужно убрать | — |
+| `app/views/review_sessions/_card_inner.html.erb:57-59` | Fallback cloze с `"` | Кавычки в fallback тоже убрать | — |
+| `app/assets/tailwind/application.css:89-104` | Стили `.inline-input` | Нет `caret-color: transparent` | — |
+
+## Test Strategy
+
+Layered Rails `/layers:spec-test` неприменим — change surface затрагивает только view template и CSS, нет controllers/operations/models.
+
+| Test surface | Canonical refs | Existing coverage | Planned automated coverage | Required local suites | Manual-only gap |
+| --- | --- | --- | --- | --- | --- |
+| View template | `REQ-01`, `SC-01` | Нет | Нет (визуальное изменение в разметке) | `bin/setup --skip-server` | Визуальная проверка в браузере |
+
+## Environment Contract
+
+| Area | Contract | Used by | Failure symptom |
+| --- | --- | --- | --- |
+| git | Feature branch `feat/027-cloze-cleanup` активна | All steps | `git branch --show-current` → не `main` |
+| setup | `bin/setup --skip-server` проходит | `CHK-01` | Ошибка компиляции assets |
+
+## Preconditions
+
+| Precondition ID | Canonical ref | Required state | Used by steps | Blocks start |
+| --- | --- | --- | --- | --- |
+| `PRE-GIT` | `engineering/git-workflow.md` | Branch `feat/027-cloze-cleanup` создана от `main` | All steps | **yes** |
+
+## Порядок работ
+
+| Step ID | Actor | Implements | Goal | Touchpoints | Artifact | Verifies | Evidence IDs | Check command | Blocked by |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `STEP-01` | agent | `REQ-01` | Убрать кавычки из шаблона | `_card_inner.html.erb:44-45,53,58` | Изменённый template | `CHK-01` | `EVID-01` | `bin/setup --skip-server` | `PRE-GIT` |
+| `STEP-02` | agent | `REQ-02` | Скрыть caret в CSS | `application.css:89-104` | Изменённый CSS | `CHK-01` | `EVID-01` | `bin/setup --skip-server` | `PRE-GIT` |
+| `STEP-REVIEW` | agent | — | Simplify review | Все изменённые файлы | Review пройден | — | — | — | `STEP-01`, `STEP-02` |
+
+## Parallelizable Work
+
+- `PAR-01` STEP-01 и STEP-02 можно выполнять параллельно — разные файлы.
+
+## Checkpoints
+
+| Checkpoint ID | Refs | Condition | Evidence IDs |
+| --- | --- | --- | --- |
+| `CP-01` | `STEP-01`, `STEP-02`, `CHK-01` | `bin/setup --skip-server` проходит, визуально нет кавычек и caret | `EVID-01` |
+
+## Готово для приемки
+
+- `bin/setup --skip-server` проходит без ошибок
+- Визуально: нет кавычек вокруг cloze-предложения, нет мигающего caret


### PR DESCRIPTION
## Summary
- Remove literal `"` quotes around cloze sentence in `_card_inner.html.erb`
- Add `caret-color: transparent` to `.inline-input` in CSS to hide blinking caret

## Test plan
- [x] `bin/setup --skip-server` passes
- [ ] Visual check: no quotes around cloze sentence
- [ ] Visual check: no blinking caret, focus shown via border-color

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)